### PR TITLE
don't run plugin content outside "the loop"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,4 @@
 ChangeLog
 =========
+- **2.0.4** Use `is_in_loop()` to avoid plugin running outside main content
 - **2.0.0** Initial release version - fork and update of v1

--- a/wp-comcar-plugins-content.php
+++ b/wp-comcar-plugins-content.php
@@ -19,8 +19,8 @@ function getToolContent( $content ) {
     global $post;
     global $wp_comcar_plugins_pages;
 
-    // we only want to process pages, not posts
-    if( !is_page() || !is_main_query() ) {
+    // we only want to process pages, not posts, sidebars, footers etc
+    if( !is_page() || !is_main_query() || !in_the_loop() ) {
         return $content;
     }
     

--- a/wp-comcar-plugins.php
+++ b/wp-comcar-plugins.php
@@ -3,12 +3,12 @@
  * Plugin Name:  Comcar Tools
  * Plugin URI: http://github.com/carmendata/comcar-wordpress-plugin/wiki
  * Description: Includes the Copmany Var Tax Calculator and MPG Calculator
- * Version: 2.0.3
+ * Version: 2.0.4
  * Author: Carmen data
  * Author URI: http://carmendata.co.uk/
  * License: GPL2
  */
-define("WP_COMCAR_PLUGINS_PLUGINVERSION","2.0.3");
+define("WP_COMCAR_PLUGINS_PLUGINVERSION","2.0.4");
 define("WP_COMCAR_PLUGINS_WEBSERVICECONTENT",dirname(__FILE__)."/webservices-calls/");
 
 # set default webservice URL if not defined in environment


### PR DESCRIPTION
# Trello

https://trello.com/c/jiawRVhl/245-fix-wp-plugins

# What is it for

Wordpress `is_in_loop` method needs using to stop content running twice

# Changes

- dont run if `!is_in_loop()`
- update version number and changelog

## Setup

n/a

# Testing

Checkout `Willshaw-patch-1` branch in staging site, confirm pages load

## Teardown

n/a
